### PR TITLE
[US1] Centered Content Layout

### DIFF
--- a/specs/002-ui-centering/tasks.md
+++ b/specs/002-ui-centering/tasks.md
@@ -17,7 +17,7 @@
 
 **Purpose**: Ajouter le token CSS fondamental — bloque toutes les USs
 
-- [ ] T001 Ajouter `--page-max-width: 1100px` dans `src/styles/tokens.css` (section Sizes ou Layout)
+- [X] T001 Ajouter `--page-max-width: 1100px` dans `src/styles/tokens.css` (section Sizes ou Layout)
 
 **Checkpoint**: Token disponible → US1 peut commencer
 
@@ -31,10 +31,10 @@
 
 ### Implémentation US1
 
-- [ ] T002 [US1] Ajouter max-width centering à `.main` dans `src/views/MainPage.module.css` : `max-width: var(--page-max-width); margin: 0 auto; width: 100%; padding: 0 var(--spacing-6);` + media query mobile `@media (max-width: 640px)` avec `max-width: none; padding: 0 var(--spacing-3);`
-- [ ] T003 [US1] Ajouter max-width centering à `.body` dans `src/components/albums/AlbumView.module.css` : même règles que T002
-- [ ] T004 [US1] Ajouter max-width centering à `.main` dans `src/views/TrashPage.module.css` : même règles que T002
-- [ ] T005 [US1] Créer `tests/e2e/ui-centering.spec.ts` avec les scénarios US1-01 à US1-04 du contrat `contracts/e2e-scenarios.md` (viewport tests avec `page.setViewportSize()`)
+- [X] T002 [US1] Ajouter max-width centering à `.main` dans `src/views/MainPage.module.css` : `max-width: var(--page-max-width); margin: 0 auto; width: 100%; padding: 0 var(--spacing-6);` + media query mobile `@media (max-width: 640px)` avec `max-width: none; padding: 0 var(--spacing-3);`
+- [X] T003 [US1] Ajouter max-width centering à `.body` dans `src/components/albums/AlbumView.module.css` : même règles que T002
+- [X] T004 [US1] Ajouter max-width centering à `.main` dans `src/views/TrashPage.module.css` : même règles que T002
+- [X] T005 [US1] Créer `tests/e2e/ui-centering.spec.ts` avec les scénarios US1-01 à US1-04 du contrat `contracts/e2e-scenarios.md` (viewport tests avec `page.setViewportSize()`)
 
 **Checkpoint**: Album grid, photo grid et trash list sont centrés à 1440px → US1 testable indépendamment
 

--- a/src/components/albums/AlbumView.module.css
+++ b/src/components/albums/AlbumView.module.css
@@ -53,4 +53,15 @@
 
 .body {
   flex: 1;
+  max-width: var(--page-max-width);
+  margin: 0 auto;
+  width: 100%;
+  padding: 0 var(--spacing-6);
+}
+
+@media (max-width: 640px) {
+  .body {
+    max-width: none;
+    padding: 0 var(--spacing-3);
+  }
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -116,6 +116,8 @@
 
   /* ===== SIZES ===== */
 
+  --page-max-width: 1100px;
+
   --size-icon-sm: 1rem;
   --size-icon-md: 1.5rem;
   --size-icon-lg: 2rem;

--- a/src/views/MainPage.module.css
+++ b/src/views/MainPage.module.css
@@ -58,4 +58,15 @@
 
 .main {
   flex: 1;
+  max-width: var(--page-max-width);
+  margin: 0 auto;
+  width: 100%;
+  padding: 0 var(--spacing-6);
+}
+
+@media (max-width: 640px) {
+  .main {
+    max-width: none;
+    padding: 0 var(--spacing-3);
+  }
 }

--- a/src/views/TrashPage.module.css
+++ b/src/views/TrashPage.module.css
@@ -49,5 +49,16 @@
 }
 
 .main {
-  padding: var(--padding-section);
+  flex: 1;
+  max-width: var(--page-max-width);
+  margin: 0 auto;
+  width: 100%;
+  padding: 0 var(--spacing-6);
+}
+
+@media (max-width: 640px) {
+  .main {
+    max-width: none;
+    padding: 0 var(--spacing-3);
+  }
 }

--- a/tests/e2e/ui-centering.spec.ts
+++ b/tests/e2e/ui-centering.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * UI Centering — E2E Acceptance Tests
+ * Feature: 002-ui-centering
+ *
+ * US1 — Centered Content Layout (T005)
+ * Scenarios: US1-01 to US1-05
+ * Contract: specs/002-ui-centering/contracts/e2e-scenarios.md
+ */
+
+async function createAlbum(page: import('@playwright/test').Page, name: string) {
+  await page.getByRole('button', { name: /create album/i }).click();
+  await page.getByLabel(/album name/i).fill(name);
+  await page.getByRole('button', { name: /^create$/i }).click();
+  await page.waitForSelector(`text=${name}`);
+}
+
+test.describe('US1 — Centered Content Layout', () => {
+  // -----------------------------------------------------------------------
+  // US1-01: Main page content centered on wide viewport (1440×900)
+  // -----------------------------------------------------------------------
+  test('US1-01: album grid is horizontally centered on 1440px viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/');
+    await page.waitForSelector('[data-testid="main-page"]');
+
+    await createAlbum(page, 'US1-01 Album');
+
+    // The .main container wraps the album grid
+    const mainContainer = page.locator('[data-testid="main-page"] > main, [data-testid="main-content"]').first();
+
+    // Fallback: locate the element that holds the album cards
+    const albumGrid = page.locator('[data-testid="album-grid"], [data-testid="album-grid-empty"]').first();
+    const boundingBox = await albumGrid.boundingBox();
+    expect(boundingBox).not.toBeNull();
+
+    const viewportWidth = 1440;
+    const leftOffset = boundingBox!.x;
+    const rightOffset = viewportWidth - (boundingBox!.x + boundingBox!.width);
+
+    // Content must not span full viewport — there should be margins
+    expect(boundingBox!.width).toBeLessThan(viewportWidth);
+    // Left and right offsets are approximately equal (within 2px tolerance)
+    expect(Math.abs(leftOffset - rightOffset)).toBeLessThanOrEqual(2);
+  });
+
+  // -----------------------------------------------------------------------
+  // US1-02: Main page is full-width on mobile (375×812)
+  // -----------------------------------------------------------------------
+  test('US1-02: album grid is near full-width on 375px mobile viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('/');
+    await page.waitForSelector('[data-testid="main-page"]');
+
+    await createAlbum(page, 'US1-02 Album');
+
+    const albumGrid = page.locator('[data-testid="album-grid"], [data-testid="album-grid-empty"]').first();
+    const boundingBox = await albumGrid.boundingBox();
+    expect(boundingBox).not.toBeNull();
+
+    // On mobile the content should be at least viewport width minus ~30px padding
+    expect(boundingBox!.width).toBeGreaterThanOrEqual(375 - 30);
+  });
+
+  // -----------------------------------------------------------------------
+  // US1-03: No horizontal scroll at any viewport width
+  // -----------------------------------------------------------------------
+  test('US1-03: no horizontal scroll at various viewport widths', async ({ page }) => {
+    const viewports = [320, 375, 640, 768, 1024, 1440, 1920, 2560];
+
+    for (const width of viewports) {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto('/');
+      await page.waitForSelector('[data-testid="main-page"]');
+
+      const hasHorizontalScroll = await page.evaluate(() => {
+        return document.documentElement.scrollWidth > document.documentElement.clientWidth;
+      });
+
+      expect(hasHorizontalScroll, `horizontal scroll at viewport width ${width}px`).toBe(false);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // US1-05: Content has min 16px padding on tablet viewport (768×1024)
+  // -----------------------------------------------------------------------
+  test('US1-05: album grid has at least 16px padding from viewport edges on 768px tablet', async ({ page }) => {
+    await page.setViewportSize({ width: 768, height: 1024 });
+    await page.goto('/');
+    await page.waitForSelector('[data-testid="main-page"]');
+
+    await createAlbum(page, 'US1-05 Album');
+
+    const albumGrid = page.locator('[data-testid="album-grid"], [data-testid="album-grid-empty"]').first();
+    const boundingBox = await albumGrid.boundingBox();
+    expect(boundingBox).not.toBeNull();
+
+    const leftPadding = boundingBox!.x;
+    const rightPadding = 768 - (boundingBox!.x + boundingBox!.width);
+
+    expect(leftPadding).toBeGreaterThanOrEqual(16);
+    expect(rightPadding).toBeGreaterThanOrEqual(16);
+  });
+
+  // -----------------------------------------------------------------------
+  // US1-04: Album view photo grid centered on wide viewport (1440×900)
+  // -----------------------------------------------------------------------
+  test('US1-04: photo grid is horizontally centered in album view on 1440px viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/');
+    await page.waitForSelector('[data-testid="main-page"]');
+
+    await createAlbum(page, 'US1-04 Album');
+
+    // Open the album
+    await page.getByText('US1-04 Album').click();
+    await page.waitForSelector('[data-testid="album-view"]');
+
+    // The .body container wraps the photo grid (or empty state)
+    const photoGrid = page.locator('[data-testid="photo-grid"], [data-testid="photo-grid-empty"]').first();
+    const boundingBox = await photoGrid.boundingBox();
+    expect(boundingBox).not.toBeNull();
+
+    const viewportWidth = 1440;
+    const leftOffset = boundingBox!.x;
+    const rightOffset = viewportWidth - (boundingBox!.x + boundingBox!.width);
+
+    // Content must not fill the entire viewport
+    expect(boundingBox!.width).toBeLessThan(viewportWidth);
+    // Left and right margins are approximately equal (within 2px tolerance)
+    expect(Math.abs(leftOffset - rightOffset)).toBeLessThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `--page-max-width: 1100px` CSS token to `src/styles/tokens.css` (T001)
- Centers `.main` in `MainPage` with `max-width` + `margin: 0 auto` and mobile media query (T002)
- Centers `.body` in `AlbumView` with the same centering rules (T003)
- Centers `.main` in `TrashPage` with the same centering rules (T004)
- Creates `tests/e2e/ui-centering.spec.ts` with Playwright scenarios US1-01 to US1-05 covering wide-viewport centering, mobile full-width, no horizontal scroll across 8 breakpoints, 16px min padding on tablet, and album view photo grid centering (T005)

## Changes

| File | Change |
|------|--------|
| `src/styles/tokens.css` | Added `--page-max-width: 1100px` in Sizes section |
| `src/views/MainPage.module.css` | Updated `.main` with centering + mobile media query |
| `src/components/albums/AlbumView.module.css` | Updated `.body` with centering + mobile media query |
| `src/views/TrashPage.module.css` | Updated `.main` with centering + mobile media query |
| `tests/e2e/ui-centering.spec.ts` | Created with 5 US1 viewport acceptance tests |
| `specs/002-ui-centering/tasks.md` | Marked T001-T005 as [X] |

## Test plan

- [ ] Run `npx playwright test tests/e2e/ui-centering.spec.ts` -- all 5 US1 scenarios pass
- [ ] Run `npm run test` -- 0 unit test regressions (pure CSS change, no JS logic modified)
- [ ] Run `npm run lint` -- no lint errors
- [ ] Manual: open app at 1440px width -- album grid and photo grid are visibly centered with equal margins
- [ ] Manual: open app at 375px -- content fills width with only small padding on both sides
- [ ] Manual: resize window at all breakpoints -- no horizontal scrollbar appears

Generated with [Claude Code](https://claude.com/claude-code)