### PR TITLE
[US2] Centered Page Headers & Toolbar

### DIFF
--- a/specs/002-ui-centering/tasks.md
+++ b/specs/002-ui-centering/tasks.md
@@ -48,13 +48,13 @@
 
 ### Implémentation US2
 
-- [ ] T006 [US2] Ajouter `.toolbarInner` dans `src/components/common/Toolbar.module.css` : `max-width: var(--page-max-width); margin: 0 auto; width: 100%; padding: 0 var(--spacing-6); display: flex; align-items: center; gap: var(--spacing-2); flex-wrap: wrap;` + media query mobile
-- [ ] T007 [US2] Wrapper le contenu de `Toolbar.tsx` dans `<div className={styles.toolbarInner}>` — les boutons Export/Import/Trash et l'input hidden deviennent enfants de ce wrapper
-- [ ] T008 [US2] Ajouter `.pageHeaderInner` dans `src/views/MainPage.module.css` : `max-width: var(--page-max-width); margin: 0 auto; width: 100%; display: flex; align-items: center; justify-content: space-between; gap: var(--spacing-4); padding: 0 var(--spacing-6);` + media query mobile
-- [ ] T009 [US2] Wrapper le contenu du `<header>` dans `MainPage.tsx` dans `<div className={styles.pageHeaderInner}>` (h1 + create button)
-- [ ] T010 [US2] Ajouter `.headerInner` dans `src/components/albums/AlbumView.module.css` : mêmes règles flex que T008
-- [ ] T011 [US2] Wrapper le contenu du header dans `AlbumView.tsx` dans `<div className={styles.headerInner}>` (back button + title + actions)
-- [ ] T012 [US2] Ajouter les scénarios US2-01 à US2-03 dans `tests/e2e/ui-centering.spec.ts`
+- [X] T006 [US2] Ajouter `.toolbarInner` dans `src/components/common/Toolbar.module.css` : `max-width: var(--page-max-width); margin: 0 auto; width: 100%; padding: 0 var(--spacing-6); display: flex; align-items: center; gap: var(--spacing-2); flex-wrap: wrap;` + media query mobile
+- [X] T007 [US2] Wrapper le contenu de `Toolbar.tsx` dans `<div className={styles.toolbarInner}>` — les boutons Export/Import/Trash et l'input hidden deviennent enfants de ce wrapper
+- [X] T008 [US2] Ajouter `.pageHeaderInner` dans `src/views/MainPage.module.css` : `max-width: var(--page-max-width); margin: 0 auto; width: 100%; display: flex; align-items: center; justify-content: space-between; gap: var(--spacing-4); padding: 0 var(--spacing-6);` + media query mobile
+- [X] T009 [US2] Wrapper le contenu du `<header>` dans `MainPage.tsx` dans `<div className={styles.pageHeaderInner}>` (h1 + create button)
+- [X] T010 [US2] Ajouter `.headerInner` dans `src/components/albums/AlbumView.module.css` : mêmes règles flex que T008
+- [X] T011 [US2] Wrapper le contenu du header dans `AlbumView.tsx` dans `<div className={styles.headerInner}>` (back button + title + actions)
+- [X] T012 [US2] Ajouter les scénarios US2-01 à US2-03 dans `tests/e2e/ui-centering.spec.ts`
 
 **Checkpoint**: Toolbar et headers alignés avec le contenu → US2 testable indépendamment
 

--- a/src/components/albums/AlbumView.module.css
+++ b/src/components/albums/AlbumView.module.css
@@ -11,13 +11,25 @@
 }
 
 .header {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-3);
-  padding: var(--spacing-3) var(--padding-card);
   background: var(--color-bg-primary);
   box-shadow: var(--shadow-sm);
   border-bottom: 1px solid var(--color-border);
+}
+
+.headerInner {
+  max-width: var(--page-max-width);
+  margin: 0 auto;
+  width: 100%;
+  padding: 0 var(--spacing-6);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+}
+
+@media (max-width: 640px) {
+  .headerInner {
+    padding: 0 var(--spacing-3);
+  }
 }
 
 .backButton {

--- a/src/components/albums/AlbumView.tsx
+++ b/src/components/albums/AlbumView.tsx
@@ -34,12 +34,14 @@ export function AlbumView({ albumId, onBack }: AlbumViewProps) {
   return (
     <div data-testid="album-view" className={styles.view}>
       <header className={styles.header}>
-        <button type="button" onClick={onBack} aria-label="Back to albums" className={styles.backButton}>
-          ← Back
-        </button>
-        <h1 className={styles.albumTitle}>{album.name}</h1>
-        <SortToggle albumId={albumId} currentMode={album.photoSortMode} onToggle={setSortMode} />
-        <AddPhotosButton albumId={albumId} />
+        <div className={styles.headerInner}>
+          <button type="button" onClick={onBack} aria-label="Back to albums" className={styles.backButton}>
+            ← Back
+          </button>
+          <h1 className={styles.albumTitle}>{album.name}</h1>
+          <SortToggle albumId={albumId} currentMode={album.photoSortMode} onToggle={setSortMode} />
+          <AddPhotosButton albumId={albumId} />
+        </div>
       </header>
 
       <main className={styles.body}>

--- a/src/components/common/Toolbar.module.css
+++ b/src/components/common/Toolbar.module.css
@@ -1,15 +1,27 @@
 .toolbar {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  padding: var(--spacing-3) var(--spacing-6);
   background-color: var(--color-bg-primary);
   border-bottom: 1px solid var(--color-border);
   box-shadow: var(--shadow-sm);
   position: sticky;
   top: 0;
   z-index: var(--z-sticky);
+}
+
+.toolbarInner {
+  max-width: var(--page-max-width);
+  margin: 0 auto;
+  width: 100%;
+  padding: 0 var(--spacing-6);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
   flex-wrap: wrap;
+}
+
+@media (max-width: 640px) {
+  .toolbarInner {
+    padding: 0 var(--spacing-3);
+  }
 }
 
 /* ---- Button base ---- */

--- a/src/components/common/Toolbar.tsx
+++ b/src/components/common/Toolbar.tsx
@@ -50,65 +50,67 @@ export function Toolbar({ onOpenTrash }: ToolbarProps) {
 
   return (
     <div data-testid="toolbar" className={styles.toolbar}>
-      <UnsavedBadge />
+      <div className={styles.toolbarInner}>
+        <UnsavedBadge />
 
-      <button
-        type="button"
-        onClick={() => void handleExport()}
-        aria-label="Export save file"
-        className={styles.buttonSecondary}
-      >
-        Export
-      </button>
+        <button
+          type="button"
+          onClick={() => void handleExport()}
+          aria-label="Export save file"
+          className={styles.buttonSecondary}
+        >
+          Export
+        </button>
 
-      <input
-        ref={importInputRef}
-        type="file"
-        accept=".zip,.photoalbum.zip,application/zip"
-        onChange={handleImportChange}
-        className={styles.hiddenInput}
-        aria-label="Select save file to import"
-      />
-      <button
-        type="button"
-        onClick={() => importInputRef.current?.click()}
-        aria-label="Import save file"
-        className={styles.buttonSecondary}
-      >
-        Import
-      </button>
-
-      <button
-        type="button"
-        onClick={onOpenTrash}
-        aria-label="Open trash"
-        className={styles.buttonSecondary}
-      >
-        Trash
-      </button>
-
-      {importError && (
-        <p role="alert" className={styles.errorMessage}>
-          {importError}
-        </p>
-      )}
-
-      {showUnsavedWarning && pendingImportFile && (
-        <ConfirmDialog
-          title="Unsaved Changes"
-          message="You have unsaved changes. Importing will replace all current data. Continue?"
-          confirmLabel="Import Anyway"
-          onConfirm={() => {
-            setShowUnsavedWarning(false);
-            void doImport(pendingImportFile);
-            setPendingImportFile(null);
-          }}
-          onCancel={() => {
-            setShowUnsavedWarning(false);
-            setPendingImportFile(null);
-          }}
+        <input
+          ref={importInputRef}
+          type="file"
+          accept=".zip,.photoalbum.zip,application/zip"
+          onChange={handleImportChange}
+          className={styles.hiddenInput}
+          aria-label="Select save file to import"
         />
-      )}
+        <button
+          type="button"
+          onClick={() => importInputRef.current?.click()}
+          aria-label="Import save file"
+          className={styles.buttonSecondary}
+        >
+          Import
+        </button>
+
+        <button
+          type="button"
+          onClick={onOpenTrash}
+          aria-label="Open trash"
+          className={styles.buttonSecondary}
+        >
+          Trash
+        </button>
+
+        {importError && (
+          <p role="alert" className={styles.errorMessage}>
+            {importError}
+          </p>
+        )}
+
+        {showUnsavedWarning && pendingImportFile && (
+          <ConfirmDialog
+            title="Unsaved Changes"
+            message="You have unsaved changes. Importing will replace all current data. Continue?"
+            confirmLabel="Import Anyway"
+            onConfirm={() => {
+              setShowUnsavedWarning(false);
+              void doImport(pendingImportFile);
+              setPendingImportFile(null);
+            }}
+            onCancel={() => {
+              setShowUnsavedWarning(false);
+              setPendingImportFile(null);
+            }}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/views/MainPage.module.css
+++ b/src/views/MainPage.module.css
@@ -6,13 +6,25 @@
 }
 
 .pageHeader {
+  background-color: var(--color-bg-primary);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.pageHeaderInner {
+  max-width: var(--page-max-width);
+  margin: 0 auto;
+  width: 100%;
+  padding: 0 var(--spacing-6);
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--spacing-4);
-  padding: var(--spacing-5) var(--spacing-6);
-  background-color: var(--color-bg-primary);
-  border-bottom: 1px solid var(--color-border);
+}
+
+@media (max-width: 640px) {
+  .pageHeaderInner {
+    padding: 0 var(--spacing-3);
+  }
 }
 
 .pageTitle {

--- a/src/views/MainPage.tsx
+++ b/src/views/MainPage.tsx
@@ -13,14 +13,16 @@ export function MainPage({ onOpenAlbum }: MainPageProps) {
   return (
     <div data-testid="main-page" className={styles.page}>
       <header className={styles.pageHeader}>
-        <h1 className={styles.pageTitle}>Photo Albums</h1>
-        <button
-          type="button"
-          className={styles.createButton}
-          onClick={() => setShowCreateForm(true)}
-        >
-          Create Album
-        </button>
+        <div className={styles.pageHeaderInner}>
+          <h1 className={styles.pageTitle}>Photo Albums</h1>
+          <button
+            type="button"
+            className={styles.createButton}
+            onClick={() => setShowCreateForm(true)}
+          >
+            Create Album
+          </button>
+        </div>
       </header>
 
       {showCreateForm && <AlbumForm onClose={() => setShowCreateForm(false)} />}

--- a/tests/e2e/ui-centering.spec.ts
+++ b/tests/e2e/ui-centering.spec.ts
@@ -132,3 +132,88 @@ test.describe('US1 — Centered Content Layout', () => {
     expect(Math.abs(leftOffset - rightOffset)).toBeLessThanOrEqual(2);
   });
 });
+
+/**
+ * US2 — Centered Page Headers & Toolbar (T012)
+ * Scenarios: US2-01 to US2-03
+ * Contract: specs/002-ui-centering/contracts/e2e-scenarios.md
+ */
+test.describe('US2 — Centered Page Headers & Toolbar', () => {
+  // -----------------------------------------------------------------------
+  // US2-01: Toolbar inner wrapper aligns with album grid on wide screen
+  // -----------------------------------------------------------------------
+  test('US2-01: toolbar inner wrapper left edge aligns with album grid left edge on 1440px viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/');
+    await page.waitForSelector('[data-testid="main-page"]');
+
+    await createAlbum(page, 'US2-01 Album');
+
+    // The toolbarInner div is the first child of the toolbar
+    const toolbarInner = page.locator('[data-testid="toolbar"] > div').first();
+    const albumGrid = page.locator('[data-testid="album-grid"], [data-testid="album-grid-empty"]').first();
+
+    const toolbarBox = await toolbarInner.boundingBox();
+    const gridBox = await albumGrid.boundingBox();
+
+    expect(toolbarBox).not.toBeNull();
+    expect(gridBox).not.toBeNull();
+
+    // Toolbar inner wrapper left edge must align with album grid left edge (within 2px)
+    expect(Math.abs(toolbarBox!.x - gridBox!.x)).toBeLessThanOrEqual(2);
+  });
+
+  // -----------------------------------------------------------------------
+  // US2-02: Album view header aligns with photo grid on wide screen
+  // -----------------------------------------------------------------------
+  test('US2-02: album view header inner left edge aligns with photo grid left edge on 1440px viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/');
+    await page.waitForSelector('[data-testid="main-page"]');
+
+    await createAlbum(page, 'US2-02 Album');
+
+    // Open the album
+    await page.getByText('US2-02 Album').click();
+    await page.waitForSelector('[data-testid="album-view"]');
+
+    // The headerInner div is the first child of the album view header
+    const headerInner = page.locator('[data-testid="album-view"] header > div').first();
+    const photoGrid = page.locator('[data-testid="photo-grid"], [data-testid="photo-grid-empty"]').first();
+
+    const headerBox = await headerInner.boundingBox();
+    const gridBox = await photoGrid.boundingBox();
+
+    expect(headerBox).not.toBeNull();
+    expect(gridBox).not.toBeNull();
+
+    // Header inner container left edge must align with photo grid left edge (within 2px)
+    expect(Math.abs(headerBox!.x - gridBox!.x)).toBeLessThanOrEqual(2);
+  });
+
+  // -----------------------------------------------------------------------
+  // US2-03: Trash page header back button aligns with trash list on wide screen
+  // -----------------------------------------------------------------------
+  test('US2-03: trash page header back button left edge aligns with trash content left edge on 1440px viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/');
+    await page.waitForSelector('[data-testid="main-page"]');
+
+    // Navigate to trash view
+    await page.getByRole('button', { name: /open trash/i }).click();
+    await page.waitForSelector('[data-testid="trash-page"]');
+
+    // Back button in the trash page header
+    const backButton = page.getByRole('button', { name: /back to albums/i });
+    const backBox = await backButton.boundingBox();
+    expect(backBox).not.toBeNull();
+
+    // Align against the trash content area (items or empty state)
+    const trashContent = page.locator('[data-testid="trash-view"], [data-testid="trash-view-empty"]').first();
+    const trashBox = await trashContent.boundingBox();
+    expect(trashBox).not.toBeNull();
+
+    // Back button left edge must align with trash content left edge (within 2px)
+    expect(Math.abs(backBox!.x - trashBox!.x)).toBeLessThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Add inner wrapper pattern to Toolbar, MainPage header, and AlbumView header so the colored background spans full width while content is constrained to `--page-max-width` and aligned with the body grid
- Strip `display: flex`, `align-items`, `gap`, `padding` from the outer containers (`.toolbar`, `.pageHeader`, `.header`) and move them into new inner wrapper classes (`.toolbarInner`, `.pageHeaderInner`, `.headerInner`)
- Add E2E acceptance tests US2-01, US2-02, US2-03 verifying left-edge alignment between inner wrappers and content areas at 1440px viewport

## Changed files

| File | Change |
|------|--------|
| `src/components/common/Toolbar.module.css` | T006 — add `.toolbarInner`, strip layout from `.toolbar` |
| `src/components/common/Toolbar.tsx` | T007 — wrap children in `<div className={styles.toolbarInner}>` |
| `src/views/MainPage.module.css` | T008 — add `.pageHeaderInner`, strip layout from `.pageHeader` |
| `src/views/MainPage.tsx` | T009 — wrap header children in `<div className={styles.pageHeaderInner}>` |
| `src/components/albums/AlbumView.module.css` | T010 — add `.headerInner`, strip layout from `.header` |
| `src/components/albums/AlbumView.tsx` | T011 — wrap header children in `<div className={styles.headerInner}>` |
| `tests/e2e/ui-centering.spec.ts` | T012 — add `US2` describe block with US2-01, US2-02, US2-03 |
| `specs/002-ui-centering/tasks.md` | Mark T006–T012 as done |

## Test plan

- [ ] US2-01: `toolbar inner wrapper left edge` === `album grid left edge` at 1440px (±2px)
- [ ] US2-02: `album view header inner left edge` === `photo grid left edge` at 1440px (±2px)
- [ ] US2-03: `trash page back button left edge` === `trash content left edge` at 1440px (±2px)
- [ ] No regression on existing US1 Playwright tests
- [ ] No regression on unit tests (`npm test`)
- [ ] Lint passes (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)